### PR TITLE
Migrate layout and screen handling to Qt6 APIs

### DIFF
--- a/src/Numpad/Numpad.cpp
+++ b/src/Numpad/Numpad.cpp
@@ -31,7 +31,6 @@
 #include <QApplication>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
-#include <QDesktopWidget>
 #include <QLabel>
 #include <QTimer>
 #include <ctime>
@@ -41,6 +40,9 @@
 #include <QSet>
 #include <WindowsX.h>
 #include <QMenuBar>
+#include <QAction>
+#include <QIcon>
+#include <QScreen>
 
 
 #pragma comment(lib,"kernel32.lib")
@@ -65,13 +67,13 @@ Numpad::Numpad(NumpadManager *_nm, QWidget *p_wid/*= 0*/)
   QHBoxLayout *p_middleLayout = new QHBoxLayout;
   p_middleLayout->addWidget(pm_buttonsBox);
   p_middleLayout->addStretch(1);
-  p_middleLayout->setMargin(0);
+  p_middleLayout->setContentsMargins(0, 0, 0, 0);
    
   QVBoxLayout *p_mainLayout = new QVBoxLayout;
 
   p_mainLayout->addLayout(p_middleLayout);
   p_mainLayout->addStretch(1);
-  p_mainLayout->setMargin(0);
+  p_mainLayout->setContentsMargins(0, 0, 0, 0);
    
   setLayout(p_mainLayout);
 
@@ -86,7 +88,8 @@ Numpad::Numpad(NumpadManager *_nm, QWidget *p_wid/*= 0*/)
 
   m_minButtonsSize = 20;
   
-  m_maxButtonsSize = QApplication::desktop()->height() / 7;  
+  QScreen *screen = QApplication::primaryScreen();
+  m_maxButtonsSize = screen->geometry().height() / 7;
 
   pm_altCodeLbl = NULL;
 
@@ -226,7 +229,8 @@ void Numpad::setButtonsSize(int size, bool correctFontSizeMode)
 
   correctAltCodeLblFontSize();
 
-  pm_gridLayout->setMargin(m_buttonsSize / 20);
+  int margin = m_buttonsSize / 20;
+  pm_gridLayout->setContentsMargins(margin, margin, margin, margin);
 
   if (correctFontSizeMode)
   {

--- a/src/Numpad/NumpadManager.cpp
+++ b/src/Numpad/NumpadManager.cpp
@@ -33,7 +33,7 @@
 #include <QColor>
 #include <QString>
 #include <QCursor>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QFontMetrics>
 #include <QSettings>
 #include <QAction>
@@ -476,15 +476,9 @@ void NumpadManager::slot_numpadSettings()
 
 void NumpadManager::slot_configure()
 {
-    int minSide;
-    if (QApplication::desktop()->height() < QApplication::desktop()->width())
-    {
-        minSide = QApplication::desktop()->height();
-    }
-    else
-    {
-        minSide = QApplication::desktop()->width();
-    }
+    QScreen *screen = QApplication::primaryScreen();
+    int minSide = screen->geometry().height() < screen->geometry().width()
+            ? screen->geometry().height() : screen->geometry().width();
     if (!allBtnWid)
     {
         allBtnWid = new AllBtnWidget(this);
@@ -630,8 +624,9 @@ void NumpadManager::showHideNumpadThroPressKey()
   }
   else
   {
-    int widthScreen = QApplication::desktop()->width();
-    int heightScreen = QApplication::desktop()->height();
+    QScreen *screen = QApplication::primaryScreen();
+    int widthScreen = screen->geometry().width();
+    int heightScreen = screen->geometry().height();
     int xCenter =  widthScreen / 2;
     int yCenter =  heightScreen / 2;
     int xCursor = QCursor::pos().x();

--- a/src/Numpad/helpwindow.cpp
+++ b/src/Numpad/helpwindow.cpp
@@ -3,7 +3,7 @@
 #include <QVBoxLayout>
 #include <Windows.h>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 
 
 HelpWindow::HelpWindow(QWidget *parent)
@@ -14,15 +14,9 @@ HelpWindow::HelpWindow(QWidget *parent)
     QFont font = textBrowser->font();
     font.setPixelSize(14);
     textBrowser->setFont(font);
-    int minSide;
-    if (QApplication::desktop()->height() < QApplication::desktop()->width())
-    {
-        minSide = QApplication::desktop()->height();
-    }
-    else
-    {
-        minSide = QApplication::desktop()->width();
-    }
+    QScreen *screen = QApplication::primaryScreen();
+    int minSide = screen->geometry().height() < screen->geometry().width()
+            ? screen->geometry().height() : screen->geometry().width();
     setMinimumHeight(minSide / 2);
     setMinimumWidth(minSide / 2);
 


### PR DESCRIPTION
## Summary
- replace deprecated `setMargin` calls with `setContentsMargins`
- swap removed `QDesktopWidget` uses for `QScreen`
- add missing headers for `QAction` and `QIcon`

## Testing
- `qmake6 numpad-emulator.pro`
- `make` *(fails: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0361abf3c832f9be5550a47517ce0