### PR TITLE
Port to modern Qt APIs

### DIFF
--- a/src/Numpad/Buttons/confbutton.cpp
+++ b/src/Numpad/Buttons/confbutton.cpp
@@ -95,7 +95,7 @@ void ConfButton::mousePressEvent(QMouseEvent *event)
 
     QDrag *drag = new QDrag(this);
     drag->setMimeData(mimeData);
-    drag->setPixmap(QPixmap::grabWidget(this));
+    drag->setPixmap(this->grab());
     drag->setHotSpot(event->pos());
 
     BtnShape shape = m_dyInfo->shape;

--- a/src/Numpad/Buttons/sourcebutton.cpp
+++ b/src/Numpad/Buttons/sourcebutton.cpp
@@ -36,7 +36,7 @@ void SourceButton::mousePressEvent(QMouseEvent *event)
 
     QDrag *drag = new QDrag(this);
     drag->setMimeData(mimeData);
-    drag->setPixmap(QPixmap::grabWidget(this));
+    drag->setPixmap(this->grab());
     drag->setHotSpot(event->pos());
 
     drag->exec(Qt::MoveAction, Qt::MoveAction);

--- a/src/Numpad/SettingsDialog.cpp
+++ b/src/Numpad/SettingsDialog.cpp
@@ -112,7 +112,7 @@ SettingsDialog::SettingsDialog(NumpadManager *p_numpadManager, Numpad *p_numpad,
   p_spacingLayout->addStretch(1);
   
   QFontMetrics font = QFontMetrics(p_buttonsSizeLbl->font());
-  int sizeGrpWidth = font.width("Buttons size");
+  int sizeGrpWidth = font.horizontalAdvance("Buttons size");
   p_buttonsSizeLbl->setFixedWidth(sizeGrpWidth);
   p_spacingLbl->setFixedWidth(sizeGrpWidth);
   p_buttonsSizeSlider->setFixedWidth(sizeGrpWidth * 2);

--- a/src/Numpad/allbtnwidget.cpp
+++ b/src/Numpad/allbtnwidget.cpp
@@ -9,8 +9,8 @@
 #include <QList>
 #include <QMenu>
 #include <QMouseEvent>
-#include <QRegExp>
-#include <QRegExpValidator>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 
 AllBtnWidget::AllBtnWidget(NumpadManager *_nm, QWidget *_parent)
@@ -41,13 +41,13 @@ AllBtnWidget::AllBtnWidget(NumpadManager *_nm, QWidget *_parent)
     gridLayout->addWidget(helpLbl, 0, 12, 1, 8);
     altCodeLineEdit = new QLineEdit;
     altCodeLineEdit->setPlaceholderText("Alt code");
-    QRegExp altCodeRX("\\d{1,4}");
-    QValidator *altCodeVal = new QRegExpValidator(altCodeRX, this);
+    QRegularExpression altCodeRX("\\d{1,4}");
+    QValidator *altCodeVal = new QRegularExpressionValidator(altCodeRX, this);
     altCodeLineEdit->setValidator(altCodeVal);
     unicodeLineEdit = new QLineEdit;
     unicodeLineEdit->setPlaceholderText("Unicode");
-    QRegExp unicodeRX("[0-9A-Fa-f]{1,4}");
-    QValidator *unicodeVal = new QRegExpValidator(unicodeRX, this);
+    QRegularExpression unicodeRX("[0-9A-Fa-f]{1,4}");
+    QValidator *unicodeVal = new QRegularExpressionValidator(unicodeRX, this);
     unicodeLineEdit->setValidator(unicodeVal);
     QPushButton *crAltCodeBtn = new QPushButton("Create special symbol");
     connect(crAltCodeBtn, SIGNAL(clicked()), SLOT(slot_crAltCodeBtnClicked()));


### PR DESCRIPTION
## Summary
- Replace deprecated QRegExp and QRegExpValidator with QRegularExpression and QRegularExpressionValidator
- Use QWidget::grab instead of removed QPixmap::grabWidget
- Update font metrics and regex parsing for Qt5/6 compatibility

## Testing
- `qmake`
- `make -j4` *(fails: fatal error: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b03aba6b94832f8a284039cb5921ed