### PR TITLE
Fix crash when toggling layout

### DIFF
--- a/src/Numpad/Buttons/Button.cpp
+++ b/src/Numpad/Buttons/Button.cpp
@@ -97,14 +97,13 @@ void Button::setStyles()
 
 void Button::mousePressEvent(QMouseEvent *)
 {
-    setPressedView();    
-
-    emit pressed(m_ids);
+    setPressedView();
     m_pressed = true;
-    if (m_autoRepeated)
+    if (m_autoRepeated && pm_delayTimer)
     {
         pm_delayTimer->start(m_autoRepeatDelay);
     }
+    emit pressed(m_ids);
 }
 
 
@@ -160,10 +159,10 @@ void Button::setAutoRepeat(bool mode)
     {
         if (!pm_delayTimer)
         {
-            pm_delayTimer = new QTimer();
+            pm_delayTimer = new QTimer(this);
             connect(pm_delayTimer, SIGNAL(timeout()),
                     this, SLOT(delayTimeout()));
-            pm_intervalTimer = new QTimer();
+            pm_intervalTimer = new QTimer(this);
             connect(pm_intervalTimer, SIGNAL(timeout()),
                     this, SLOT(intervalTimeout()));
         }


### PR DESCRIPTION
## Summary
- avoid segmentation fault on layout toggle by starting auto-repeat timer before emitting the pressed signal
- attach auto-repeat timers to their button so they are cleaned up with the widget

## Testing
- `qmake`
- `make` *(fails: fatal error: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b043dbff6c832f88dd72dafd52c7d6