### PR TITLE
Anchor layout toggle to bottom-right

### DIFF
--- a/src/Numpad/NumpadManager.cpp
+++ b/src/Numpad/NumpadManager.cpp
@@ -1452,17 +1452,15 @@ void NumpadManager::toggleLayout()
     int x = pm_numpad->pos().x();
     int y = pm_numpad->pos().y();
     int prevWidth = pm_numpad->width();
+    int prevHeight = pm_numpad->height();
     confFileName = (confFileName == numericConfFileName) ? qwertyConfFileName : numericConfFileName;
     checkConfFile();
     slot_reloadConfig();
-    if (confFileName == qwertyConfFileName)
-    {
-        pm_numpad->move(x - pm_numpad->width(), y);
-    }
-    else
-    {
-        pm_numpad->move(x + prevWidth, y);
-    }
+
+    // keep the bottom-right corner anchored when switching layouts
+    int newX = x + prevWidth - pm_numpad->width();
+    int newY = y + prevHeight - pm_numpad->height();
+    pm_numpad->move(newX, newY);
 }
 
 


### PR DESCRIPTION
## Summary
- Ensure layout toggling keeps the numpad's bottom-right corner fixed, maintaining consistent positioning when switching layouts.

## Testing
- `qmake`
- `make -j4` *(fails: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b046cecc94832f8c7c5015e7c68f4c