### PR TITLE
Update layout toggle button label

### DIFF
--- a/src/Numpad/NumpadManager.cpp
+++ b/src/Numpad/NumpadManager.cpp
@@ -1076,7 +1076,8 @@ void NumpadManager::loadBtnsStaticInfo()
     m_btnsStInfo[162] = new BtnStaticInfo("Z", false, QList<int>() << 0x5A);
     m_btnsStInfo[163] = new BtnStaticInfo(".", true, QList<int>() << VK_NUMPAD4 << VK_NUMPAD6);
     m_btnsStInfo[164] = new BtnStaticInfo(" ", false, QList<int>() << VK_SPACE);
-    m_btnsStInfo[165] = new BtnStaticInfo("layout", false, QList<int>());
+    QString layoutLabel = (confFileName == numericConfFileName) ? "abc" : "123";
+    m_btnsStInfo[165] = new BtnStaticInfo(layoutLabel, false, QList<int>());
 }
 
 
@@ -1453,6 +1454,7 @@ void NumpadManager::toggleLayout()
     int y = pm_numpad->pos().y();
     int prevWidth = pm_numpad->width();
     confFileName = (confFileName == numericConfFileName) ? qwertyConfFileName : numericConfFileName;
+    m_btnsStInfo[165]->view = (confFileName == numericConfFileName) ? "abc" : "123";
     checkConfFile();
     slot_reloadConfig();
     if (confFileName == qwertyConfFileName)


### PR DESCRIPTION
## Summary
- Display "abc" on layout toggle button in numpad mode
- Display "123" on layout toggle button in qwerty mode

## Testing
- `qmake numpad-emulator.pro`
- `make` *(fails: Windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b04971c720832faa6ab653659e34eb