### PR TITLE
Prevent duplicate key activation when using touch

### DIFF
--- a/src/Numpad/Buttons/Button.cpp
+++ b/src/Numpad/Buttons/Button.cpp
@@ -98,8 +98,13 @@ void Button::setStyles()
 }
 
 
-void Button::mousePressEvent(QMouseEvent *)
+void Button::mousePressEvent(QMouseEvent *event)
 {
+    if (event->source() == Qt::MouseEventSynthesizedByQt)
+    {
+        event->ignore();
+        return;
+    }
     setPressedView();
     m_pressed = true;
     if (m_autoRepeated && pm_delayTimer)
@@ -110,8 +115,13 @@ void Button::mousePressEvent(QMouseEvent *)
 }
 
 
-void Button::mouseReleaseEvent(QMouseEvent *)
+void Button::mouseReleaseEvent(QMouseEvent *event)
 {
+    if (event->source() == Qt::MouseEventSynthesizedByQt)
+    {
+        event->ignore();
+        return;
+    }
     m_pressed = false;
     if (!m_checkable)
     {

--- a/src/Numpad/Buttons/Button.h
+++ b/src/Numpad/Buttons/Button.h
@@ -24,6 +24,7 @@
 #include <QLabel>
 #include <QTimer>
 #include <QList>
+#include <QMouseEvent>
 
 class QString;
 class QEvent;
@@ -67,8 +68,8 @@ private:
   QList<int> m_ids;
 
 protected:
-  void mousePressEvent(QMouseEvent *);
-  void mouseReleaseEvent(QMouseEvent *);
+  void mousePressEvent(QMouseEvent *event) override;
+  void mouseReleaseEvent(QMouseEvent *event) override;
   bool event(QEvent *) override;
 protected slots:
   void intervalTimeout();


### PR DESCRIPTION
## Summary
- ignore Qt-synthesized mouse events that follow touch interactions on virtual keypad buttons
- update button overrides to use event objects so synthesized mouse clicks are skipped

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901ccaf54a0832fa854d6823f71fa38