### PR TITLE
Fix duplicate touch input by ignoring synthesized mouse events

### DIFF
--- a/src/Numpad/Buttons/Button.cpp
+++ b/src/Numpad/Buttons/Button.cpp
@@ -100,7 +100,7 @@ void Button::setStyles()
 
 void Button::mousePressEvent(QMouseEvent *event)
 {
-    if (event->source() == Qt::MouseEventSynthesizedByQt)
+    if (event->source() != Qt::MouseEventNotSynthesized)
     {
         event->ignore();
         return;
@@ -117,7 +117,7 @@ void Button::mousePressEvent(QMouseEvent *event)
 
 void Button::mouseReleaseEvent(QMouseEvent *event)
 {
-    if (event->source() == Qt::MouseEventSynthesizedByQt)
+    if (event->source() != Qt::MouseEventNotSynthesized)
     {
         event->ignore();
         return;


### PR DESCRIPTION
## Summary
- prevent virtual numpad buttons from reacting to mouse events synthesized from touch interactions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901d2798ab4832f854eb8c34f92eaa6