### PR TITLE
Add technical wiki documenting Virtual Numpad

### DIFF
--- a/docs/wiki/ApplicationFlow.md
+++ b/docs/wiki/ApplicationFlow.md
@@ -1,0 +1,19 @@
+# Arquitectura y ciclo de vida
+
+## Punto de entrada
+
+La ejecución comienza en `main.cpp`, donde se inicializa la instancia de `QApplication`, se crea un `SingleInstanceGuard` para evitar múltiples procesos simultáneos y se conecta la señal de activación al `NumpadManager` antes de iniciar el bucle principal de Qt.【F:src/Numpad/main.cpp†L21-L39】
+
+## Control de instancia única
+
+`SingleInstanceGuard` utiliza un `QLocalServer` para reclamar un nombre de servidor exclusivo. Si otra instancia intenta ejecutarse, se conecta al servidor existente, envía un mensaje `activate` y provoca que la instancia principal emita la señal `activationRequested`. El destructor elimina el servidor para liberar el recurso cuando la aplicación finaliza.【F:src/Numpad/SingleInstanceGuard.cpp†L1-L82】【F:src/Numpad/SingleInstanceGuard.h†L1-L32】
+
+## Rol del `NumpadManager`
+
+`NumpadManager` actúa como orquestador general: configura iconos, menús y diálogo de ajustes, inicializa las configuraciones por defecto y carga tanto la información estática de botones como la disposición actual desde archivo. También instala el *hook* global del teclado cargando dinámicamente `KeyboardHook.dll` y registrando un protocolo personalizado para la comunicación con el sistema.【F:src/Numpad/NumpadManager.cpp†L65-L158】
+
+Además, escucha mensajes nativos de Windows mediante `nativeEvent`. Allí intercepta el mensaje personalizado `KEYBOARDHOOKMSG` para invocar `slot_showHideNumpad` cuando se detecta la tecla configurada, y responde a `WM_QUERYENDSESSION` cerrando la aplicación de forma ordenada.【F:src/Numpad/NumpadManager.cpp†L604-L624】【F:src/Numpad/KeyboardHookMsg.h†L21-L26】
+
+## Ciclo de visibilidad y foco
+
+Las peticiones para mostrar u ocultar el teclado virtual terminan en `slot_showHideNumpad`, que sincroniza el estado del menú contextual y alterna la ventana entre visible, minimizada u oculta manteniendo el estilo "no activar". Cuando se requiere llevar la aplicación al frente (por ejemplo, tras recibir `activationRequested`), `bringToForeground` restaura la ventana, la enfoca y asegura que se muestre sobre otras aplicaciones.【F:src/Numpad/NumpadManager.cpp†L452-L472】【F:src/Numpad/NumpadManager.cpp†L888-L916】

--- a/docs/wiki/AuxiliaryTools.md
+++ b/docs/wiki/AuxiliaryTools.md
@@ -1,0 +1,17 @@
+# Herramientas auxiliares y utilidades
+
+## Lanzador de personalización
+
+Al seleccionar "Add/Remove buttons" desde el menú, `NumpadManager::slot_configure` abre dos ventanas: `AllBtnWidget` con la biblioteca de botones disponibles y `DndNumpad` para editar mediante arrastrar y soltar. Ambas se dimensionan en función de la pantalla para facilitar el trabajo simultáneo.【F:src/Numpad/NumpadManager.cpp†L488-L519】
+
+## Editor visual (`DndNumpad`)
+
+`DndNumpad` presenta un grid ampliado donde cada celda contiene un `ConfButton`. Permite arrastrar, copiar y cambiar el tamaño de los botones existentes, y muestra instrucciones contextuales sobre cómo combinarlo con la ventana "All buttons". Al aplicar los cambios, delega en el `NumpadManager` la actualización del archivo de configuración.【F:src/Numpad/dndnumpad.cpp†L16-L200】
+
+## Biblioteca de botones (`AllBtnWidget`)
+
+`AllBtnWidget` lista todas las combinaciones disponibles (`getAllBtnsConfig`) y ofrece herramientas para crear botones personalizados a partir de texto libre o códigos Alt/Unicode. Los botones generados pueden copiarse o arrastrarse al editor visual, y cualquier símbolo no soportado se reporta al usuario en la misma ventana.【F:src/Numpad/allbtnwidget.cpp†L16-L199】
+
+## Acceso a la ayuda
+
+Desde cualquiera de las ventanas de configuración se puede abrir la ayuda integrada. `NumpadManager::showHelp` garantiza que la ventana `HelpWindow` se cree una sola vez, se muestre en primer plano y navegue hasta la sección solicitada antes de devolver el foco al sistema.【F:src/Numpad/NumpadManager.cpp†L580-L587】

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -1,0 +1,21 @@
+# Sistema de configuración y persistencia
+
+## Preferencias de interfaz
+
+`NumpadManager` guarda ajustes visuales y de comportamiento mediante `QSettings`, incluyendo la visibilidad del menú contextual, la presencia del botón de cambio de diseño y la última posición conocida de la ventana. Las llamadas de escritura se agrupan en métodos como `writeMenuVisibleToSettings`, `writeLayoutBtnVisibleToSettings` y `writeNumpadPosition`, mientras que `readNumpadPosition` decide si recuperar la posición almacenada o la inicial en función de la preferencia "Recordar última posición".【F:src/Numpad/NumpadManager.cpp†L772-L843】
+
+También persiste la posición inicial manual, el estado "recordar" y valida las coordenadas contra las pantallas disponibles para evitar que el teclado aparezca fuera de la vista.【F:src/Numpad/NumpadManager.cpp†L846-L974】
+
+## Configuración desde la UI
+
+El `SettingsDialog` ofrece controles para alternar el menú del engrane, mostrar el selector de diseño, activar el inicio automático con Windows, gestionar la posición inicial y elegir la tecla global que muestra/oculta el teclado, siempre que el *hook* global se haya instalado correctamente.【F:src/Numpad/SettingsDialog.cpp†L69-L167】
+
+También expone deslizadores para tamaño y espaciado de botones, junto con selectores de color y tipografía que delegan en el `Numpad` para aplicar los cambios y que luego son almacenados por el `NumpadManager`.【F:src/Numpad/SettingsDialog.cpp†L168-L199】【F:src/Numpad/NumpadManager.cpp†L423-L441】
+
+## Definiciones estáticas de botones
+
+El método `loadBtnsStaticInfo` crea un mapa de `BtnStaticInfo` que asocia cada identificador con su representación HTML y códigos de teclado/Alt correspondientes. La lista incluye dígitos numéricos, símbolos especiales, teclas de función y variantes alfanuméricas para generar palabras completas mediante códigos Alt.【F:src/Numpad/NumpadManager.cpp†L1120-L1260】
+
+## Tecla global de activación
+
+`setShowHideKey` busca en la colección pre-cargada de teclas rápidas y, si el *hook* está operativo, actualiza los atajos de menú para reflejar la tecla seleccionada. Esto permite que la misma tecla sirva tanto para alternar desde el sistema como desde la interfaz.【F:src/Numpad/NumpadManager.cpp†L430-L444】

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,12 @@
+# Wiki del proyecto Virtual Numpad
+
+Esta wiki recopila la información técnica más relevante del emulador de teclado numérico virtual. Está organizada en varias páginas temáticas que describen el flujo principal de la aplicación, los componentes de la interfaz, el sistema de configuración y las herramientas de personalización disponibles para el usuario final.
+
+## Índice
+
+1. [Arquitectura y ciclo de vida](ApplicationFlow.md)
+2. [Componentes de la interfaz de usuario](UIComponents.md)
+3. [Sistema de configuración y persistencia](Configuration.md)
+4. [Herramientas auxiliares y utilidades](AuxiliaryTools.md)
+
+Cada sección contiene referencias directas al código fuente para facilitar la navegación dentro del repositorio.

--- a/docs/wiki/UIComponents.md
+++ b/docs/wiki/UIComponents.md
@@ -1,0 +1,21 @@
+# Componentes de la interfaz de usuario
+
+## Ventana principal del teclado
+
+La clase `Numpad` construye la ventana flotante con estilo de herramienta siempre visible, inicializa un `QGridLayout` para los botones y añade una barra de menú con un icono de engrane que delega en el `NumpadManager` cuando se activa.【F:src/Numpad/Numpad.cpp†L56-L118】
+
+El widget calcula márgenes mínimos/máximos para tamaño y espacio entre botones en función de la resolución de la pantalla primaria, y mantiene un temporizador (`pm_rstrTimer`) para gestionar la repetición automática sin que la ventana obtenga el foco gracias al estilo "no activar".【F:src/Numpad/Numpad.cpp†L99-L118】
+
+## Tipos de botones y disposición
+
+La estructura `BtnDynamicInfo` define la forma (cuadrada, horizontal grande o vertical grande) y posición de cada botón. `Numpad::createButtons` recorre la configuración actual, combina la representación visual (`BtnStaticInfo::view`) y construye instancias específicas (`Button`, `BigHorizontalButton`, `BigVerticalButton`) según la forma deseada.【F:src/Numpad/btninfo.h†L1-L24】【F:src/Numpad/Numpad.cpp†L137-L218】
+
+Ciertas teclas (Alt, Ctrl, Shift) se marcan como *checkable* para mantener su estado mientras el usuario compone combinaciones, y el resto queda en modo auto-repetición para soportar pulsaciones prolongadas.【F:src/Numpad/Numpad.cpp†L139-L181】
+
+## Comportamiento de `Button`
+
+Cada `Button` hereda de `QLabel`, acepta eventos táctiles y de ratón, y controla internamente los colores de texto y fondo para los estados presionado y reposo. Implementa un temporizador de retardo más uno de intervalo para habilitar la repetición automática y emite señales diferenciadas para pulsaciones y cambios de estado en botones conmutables.【F:src/Numpad/Buttons/Button.cpp†L26-L198】
+
+## Indicadores y ayudas visuales
+
+Cuando se activa el modo de códigos Alt, `createAltCodeLbl` muestra mensajes rotatorios con combinaciones útiles dentro del grid, reforzando el objetivo de introducir símbolos extendidos desde Windows.【F:src/Numpad/Numpad.cpp†L191-L197】


### PR DESCRIPTION
## Summary
- add a project wiki index and link it to new detailed documentation pages
- describe application flow, UI components, configuration system, and auxiliary tools with code references

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690c788dc160832fa6b10386ed75683c